### PR TITLE
feat: 폴더 생성(중복처리) 및 조회 구현

### DIFF
--- a/src/main/java/com/sparta/myselectshop/controller/FolderController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/FolderController.java
@@ -1,0 +1,27 @@
+package com.sparta.myselectshop.controller;
+
+import com.sparta.myselectshop.dto.FolderRequestDto;
+import com.sparta.myselectshop.security.UserDetailsImpl;
+import com.sparta.myselectshop.service.FolderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class FolderController {
+
+    private final FolderService folderService;
+
+    @PostMapping("/folders")
+    public void addFolders(@RequestBody FolderRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<String> folderNames = requestDto.getFolderNames();
+        folderService.addFolders(folderNames, userDetails.getUser());
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/controller/UserController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/UserController.java
@@ -4,12 +4,14 @@ import com.sparta.myselectshop.dto.SignupRequestDto;
 import com.sparta.myselectshop.dto.UserInfoDto;
 import com.sparta.myselectshop.entity.UserRoleEnum;
 import com.sparta.myselectshop.security.UserDetailsImpl;
+import com.sparta.myselectshop.service.FolderService;
 import com.sparta.myselectshop.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +28,8 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
+
+    private final FolderService folderService;
 
     @GetMapping("/user/login-page")
     public String loginPage() {
@@ -62,5 +66,11 @@ public class UserController {
         boolean isAdmin = (role == UserRoleEnum.ADMIN);
 
         return new UserInfoDto(username, isAdmin);
+    }
+
+    @GetMapping("/user-folder")
+    public String getUserInfo(Model model, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        model.addAttribute("folders", folderService.getFolders(userDetails.getUser()));
+        return "index :: #fragment";
     }
 }

--- a/src/main/java/com/sparta/myselectshop/dto/FolderRequestDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/FolderRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.myselectshop.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class FolderRequestDto {
+    List<String> folderNames;
+}

--- a/src/main/java/com/sparta/myselectshop/dto/FolderResponseDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/FolderResponseDto.java
@@ -1,0 +1,15 @@
+package com.sparta.myselectshop.dto;
+
+import com.sparta.myselectshop.entity.Folder;
+import lombok.Getter;
+
+@Getter
+public class FolderResponseDto {
+    private Long id;
+    private String name;
+
+    public FolderResponseDto(Folder folder) {
+        this.id = folder.getId();
+        this.name = folder.getName();
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/ProductResponseDto.java
@@ -1,8 +1,12 @@
 package com.sparta.myselectshop.dto;
 
 import com.sparta.myselectshop.entity.Product;
+import com.sparta.myselectshop.entity.ProductFolder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -14,6 +18,8 @@ public class ProductResponseDto {
     private int lprice;
     private int myprice;
 
+    private List<FolderResponseDto> productFolderList = new ArrayList<>();
+
     public ProductResponseDto(Product product) {
         this.id = product.getId();
         this.title = product.getTitle();
@@ -21,5 +27,10 @@ public class ProductResponseDto {
         this.image = product.getImage();
         this.lprice = product.getLprice();
         this.myprice = product.getMyprice();
+
+        for (ProductFolder productFolder : product.getProductFolderList()) {
+            productFolderList.add(new FolderResponseDto(productFolder.getFolder()));
+            
+        }
     }
 }

--- a/src/main/java/com/sparta/myselectshop/repository/FolderRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/FolderRepository.java
@@ -1,7 +1,14 @@
 package com.sparta.myselectshop.repository;
 
 import com.sparta.myselectshop.entity.Folder;
+import com.sparta.myselectshop.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FolderRepository extends JpaRepository<Folder, Long> {
+    // SELECT * FROM folder WHERE user_id = ? AND name IN (?, ?, ...);
+    List<Folder> findAllByUserAndNameIn(User user, List<String> folderNames);
+
+    List<Folder> findAllByUser(User user);
 }

--- a/src/main/java/com/sparta/myselectshop/service/FolderService.java
+++ b/src/main/java/com/sparta/myselectshop/service/FolderService.java
@@ -1,0 +1,54 @@
+package com.sparta.myselectshop.service;
+
+import com.sparta.myselectshop.dto.FolderResponseDto;
+import com.sparta.myselectshop.entity.Folder;
+import com.sparta.myselectshop.entity.User;
+import com.sparta.myselectshop.repository.FolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FolderService {
+
+    private final FolderRepository folderRepository;
+
+    public void addFolders(List<String> folderNames, User user) {
+
+        List<Folder> existFolderList = folderRepository.findAllByUserAndNameIn(user, folderNames);
+
+        List<Folder> newFolderList = new ArrayList<>();
+
+        for (String folderName : folderNames) {
+            if(!isExistFolderName(folderName, existFolderList)) {
+                Folder newFolder = new Folder(folderName, user);
+                newFolderList.add(newFolder);
+            } else {
+                throw new IllegalArgumentException("폴더명이 중복되었습니다.");
+            }
+        }
+
+        folderRepository.saveAll(newFolderList);
+    }
+
+    public List<FolderResponseDto> getFolders(User user) {
+        List<Folder> folderList = folderRepository.findAllByUser(user);
+        List<FolderResponseDto> responseDtoList = new ArrayList<>();
+        for (Folder folder : folderList) {
+            responseDtoList.add(new FolderResponseDto(folder));
+        }
+        return responseDtoList;
+    }
+
+    private boolean isExistFolderName(String folderName, List<Folder> existFolderList) {
+        for (Folder existFolder : existFolderList) {
+            if(folderName.equals(existFolder.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -48,6 +48,7 @@ public class ProductService {
         return new ProductResponseDto(findRroduct);
     }
 
+    @Transactional(readOnly = true)
     public Page<ProductResponseDto> getProducts(User user, int page, int size, String sortBy, boolean isAse) {
         Sort.Direction direction = isAse ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);


### PR DESCRIPTION
- close #21 
- 테스트 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 로그인 사용자가 여러 폴더를 한 번에 생성할 수 있는 엔드포인트가 추가되었습니다.
  - 내 폴더 목록을 불러와 화면 일부에 렌더링하는 경로가 추가되어, 페이지 새로고침 없이 폴더 리스트를 갱신할 수 있습니다.
  - 상품 응답에 해당 상품이 속한 폴더 정보가 포함되어, UI에서 상품별 폴더를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->