### PR TITLE
feat: 인가코드로 access_token 가져오 & 카카오 사용자 정보 가져오기 구현(토큰으로 로그인은 아직 구현 X)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.1.0'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/com/sparta/myselectshop/config/RestTemplateConfig.java
+++ b/src/main/java/com/sparta/myselectshop/config/RestTemplateConfig.java
@@ -1,0 +1,26 @@
+package com.sparta.myselectshop.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig  {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                // RestTemplate 으로 외부 API 호출 시 일정 시간이 지나도 응답이 없을 때
+                // 무한 대기 상태 방지를 위해 강제 종료 설정
+                .setConnectTimeout(Duration.ofMillis(5000)) // 5초
+                .setReadTimeout(Duration.ofMillis(5000)) // 5초
+                .build();
+
+        // 강의에서 다룬 아래 .setConnectTimeout과 .setReadTimeout는 DEPRECATED 되었습니다. 위에 작성된 최신 버전의 코드로 대체합니다.
+        //.setConnectTimeout(Duration.ofSeconds(5))
+        //.setReadTimeout(Duration.ofSeconds(5))
+        //.build();
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/controller/UserController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/UserController.java
@@ -1,11 +1,16 @@
 package com.sparta.myselectshop.controller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sparta.myselectshop.dto.SignupRequestDto;
 import com.sparta.myselectshop.dto.UserInfoDto;
 import com.sparta.myselectshop.entity.UserRoleEnum;
+import com.sparta.myselectshop.jwt.JwtUtil;
 import com.sparta.myselectshop.security.UserDetailsImpl;
 import com.sparta.myselectshop.service.FolderService;
+import com.sparta.myselectshop.service.KakaoService;
 import com.sparta.myselectshop.service.UserService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,10 +19,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,8 +30,9 @@ import java.util.List;
 public class UserController {
 
     private final UserService userService;
-
     private final FolderService folderService;
+    private final KakaoService kakaoService;
+    private final JwtUtil jwtUtil;
 
     @GetMapping("/user/login-page")
     public String loginPage() {
@@ -73,4 +76,16 @@ public class UserController {
         model.addAttribute("folders", folderService.getFolders(userDetails.getUser()));
         return "index :: #fragment";
     }
+
+    @GetMapping("/user/kakao/callback")
+    public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
+        String token = kakaoService.kakaoLogin(code);
+
+        Cookie cookie = new Cookie(jwtUtil.AUTHORIZATION_HEADER, token);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return "redirect:/";
+    }
+
 }

--- a/src/main/java/com/sparta/myselectshop/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/sparta/myselectshop/dto/KakaoUserInfoDto.java
@@ -1,0 +1,18 @@
+package com.sparta.myselectshop.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String nickname;
+    private String email;
+
+    public KakaoUserInfoDto(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/naver/service/NaverApiService.java
+++ b/src/main/java/com/sparta/myselectshop/naver/service/NaverApiService.java
@@ -22,6 +22,7 @@ public class NaverApiService {
 
     private final RestTemplate restTemplate;
 
+    // 자동으로 RestTemplate 관리 가능 config.RestTemplate로 수동등록 가능
     public NaverApiService(RestTemplateBuilder builder) {
         this.restTemplate = builder.build();
     }

--- a/src/main/java/com/sparta/myselectshop/service/KakaoService.java
+++ b/src/main/java/com/sparta/myselectshop/service/KakaoService.java
@@ -1,0 +1,114 @@
+package com.sparta.myselectshop.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.myselectshop.dto.KakaoUserInfoDto;
+import com.sparta.myselectshop.jwt.JwtUtil;
+import com.sparta.myselectshop.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Slf4j(topic = "KAKAO Login(KakaoService.class)")
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate;
+    private final JwtUtil jwtUtil;
+
+    public String kakaoLogin(String code) throws JsonProcessingException {
+        // 1. "인가 코드"로 "액세스 토큰" 요청
+        String accessToken = getToken(code);
+
+        // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
+        KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+
+        return null;
+    }
+
+    private String getToken(String code) throws JsonProcessingException {
+        log.info("인가코드 : " + code);
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kauth.kakao.com")
+                .path("/oauth/token")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", "ea02cc20577fcd25813ea596ea1b3480");
+        body.add("redirect_uri", "http://localhost:8080/api/user/kakao/callback");
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        log.info("accessToken : " + accessToken);
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://kapi.kakao.com")
+                .path("/v2/user/me")
+                .encode()
+                .build()
+                .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+                .post(uri)
+                .headers(headers)
+                .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+                requestEntity,
+                String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties").get("nickname").asText();
+        String email = jsonNode.get("kakao_account").get("email").asText();
+
+        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
+        return new KakaoUserInfoDto(id, nickname, email);
+    }
+}

--- a/src/main/java/com/sparta/myselectshop/service/ProductService.java
+++ b/src/main/java/com/sparta/myselectshop/service/ProductService.java
@@ -16,8 +16,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
 @Service

--- a/src/main/resources/static/js/basic.js
+++ b/src/main/resources/static/js/basic.js
@@ -428,10 +428,16 @@ function logout() {
 }
 
 function getToken() {
+
     let auth = Cookies.get('Authorization');
 
     if(auth === undefined) {
         return '';
+    }
+
+    // kakao 로그인 사용한 경우 Bearer 추가
+    if(auth.indexOf('Bearer') === -1 && auth !== ''){
+        auth = 'Bearer ' + auth;
     }
 
     return auth;

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -16,7 +16,9 @@
 <body>
 <div id="login-form">
     <div id="login-title">Log into Select Shop</div>
-    <br>
+    <button id="login-kakao-btn" onclick="location.href='https://kauth.kakao.com/oauth/authorize?client_id=ea02cc20577fcd25813ea596ea1b3480&redirect_uri=http://localhost:8080/api/user/kakao/callback&response_type=code'">
+        카카오로 로그인하기
+    </button>
     <button id="login-id-btn" onclick="location.href='/api/user/signup'">
         회원 가입하기
     </button>


### PR DESCRIPTION
- close #27 
- 테스트 완료(토큰받기 완료, 로그인 미완료)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 카카오 로그인 추가: 로그인 페이지에 “카카오로 로그인하기” 버튼 도입, OAuth 콜백 엔드포인트 제공, 로그인 후 JWT 쿠키 설정 및 홈으로 리다이렉트
* Bug Fixes
  * 인증 토큰 정규화: Authorization 값에 Bearer 접두사가 없을 경우 자동 추가로 인증 오류 감소
* Chores
  * 빌드 플러그인 버전 조정 및 HTTP 요청 타임아웃 기본 설정
* Documentation
  * RestTemplate 사용 관련 안내 주석 보강

<!-- end of auto-generated comment: release notes by coderabbit.ai -->