### PR TITLE
feat: 카카오 사용자 정보로 회원가입 구현(중복계정 불가)

### DIFF
--- a/src/main/java/com/sparta/myselectshop/controller/UserController.java
+++ b/src/main/java/com/sparta/myselectshop/controller/UserController.java
@@ -81,7 +81,8 @@ public class UserController {
     public String kakaoLogin(@RequestParam String code, HttpServletResponse response) throws JsonProcessingException {
         String token = kakaoService.kakaoLogin(code);
 
-        Cookie cookie = new Cookie(jwtUtil.AUTHORIZATION_HEADER, token);
+        // TODO 쿠키토큰 값 확인하기
+        Cookie cookie = new Cookie(jwtUtil.AUTHORIZATION_HEADER, token.substring(7));
         cookie.setPath("/");
         response.addCookie(cookie);
 

--- a/src/main/java/com/sparta/myselectshop/entity/User.java
+++ b/src/main/java/com/sparta/myselectshop/entity/User.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -28,10 +31,25 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private UserRoleEnum role;
 
+    private Long kakaoId;
+
     public User(String username, String password, String email, UserRoleEnum role) {
         this.username = username;
         this.password = password;
         this.email = email;
         this.role = role;
+    }
+
+    public User(String username, String password, String email, UserRoleEnum role, Long kakaoId) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.role = role;
+        this.kakaoId =kakaoId;
+    }
+
+    public User kakaoIdUpdate(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
     }
 }

--- a/src/main/java/com/sparta/myselectshop/repository/UserRepository.java
+++ b/src/main/java/com/sparta/myselectshop/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByKakaoId(Long kakaoId);
 }

--- a/src/main/java/com/sparta/myselectshop/service/KakaoService.java
+++ b/src/main/java/com/sparta/myselectshop/service/KakaoService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.myselectshop.dto.KakaoUserInfoDto;
+import com.sparta.myselectshop.entity.User;
+import com.sparta.myselectshop.entity.UserRoleEnum;
 import com.sparta.myselectshop.jwt.JwtUtil;
 import com.sparta.myselectshop.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.UUID;
 
 @Slf4j(topic = "KAKAO Login(KakaoService.class)")
 @Service
@@ -37,7 +40,13 @@ public class KakaoService {
         // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
         KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
 
-        return null;
+        // 3. 필요시에 회원가입
+        User kakaoUser = registerKakaoUserIfNeeded(kakaoUserInfo);
+
+        // 4. JWT 토큰 반환
+        String createToken = jwtUtil.createToken(kakaoUser.getUsername(), kakaoUser.getRole());
+
+        return createToken;
     }
 
     private String getToken(String code) throws JsonProcessingException {
@@ -110,5 +119,36 @@ public class KakaoService {
 
         log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
         return new KakaoUserInfoDto(id, nickname, email);
+    }
+
+    // 계정을 2개 만들지 않고 1개로 통합
+    private User registerKakaoUserIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
+        // DB 에 중복된 Kakao Id 가 있는지 확인
+        Long kakaoId = kakaoUserInfo.getId();
+        User kakaoUser = userRepository.findByKakaoId(kakaoId).orElse(null); // 없다면 null 반환
+
+        if (kakaoUser == null) {
+            // 카카오 사용자 email 동일한 email 가진 회원이 있는지 확인(이미 이메일로 회원가입 했을때)
+            String kakaoEmail = kakaoUserInfo.getEmail();
+            User sameEmailUser = userRepository.findByEmail(kakaoEmail).orElse(null);
+            if (sameEmailUser != null) {
+                kakaoUser = sameEmailUser;
+                // 기존 회원정보에 카카오 Id 추가
+                kakaoUser = kakaoUser.kakaoIdUpdate(kakaoId);
+            } else {
+                // 신규 회원가입
+                // password: random UUID
+                String password = UUID.randomUUID().toString();
+                String encodedPassword = passwordEncoder.encode(password);
+
+                // email: kakao email
+                String email = kakaoUserInfo.getEmail();
+
+                kakaoUser = new User(kakaoUserInfo.getNickname(), encodedPassword, email, UserRoleEnum.USER, kakaoId);
+            }
+
+            userRepository.save(kakaoUser); // 트랜젝션 걸지 않고 save()호출이 더 효율적일지도 모른다
+        }
+        return kakaoUser;
     }
 }


### PR DESCRIPTION
- close #29 
- 테스트 완료
- 중복계정을 막기 위해 User에 필드로 kakaoId 추가
- TODO 쿠키값 반환 살펴보기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 카카오 계정으로 회원가입/로그인을 지원합니다.
  * 최초 카카오 로그인 시 계정이 없는 경우 자동으로 회원이 생성됩니다.
  * 기존 이메일 계정이 있는 경우 카카오 계정과 자동으로 연동됩니다.
  * 로그인 성공 시 JWT가 발급되어 쿠키에 저장되며, 이후 요청에 사용됩니다.
  * 로그인 후 기존과 동일하게 페이지로 리다이렉트됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->